### PR TITLE
Remove usage of \JSON_THROW_ON_ERROR

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -20,8 +20,7 @@ final class ExceptionHandler
                     'line_from' => $throwable->getLine(),
                     'type' => 'psalm_error'
                 ]
-            ],
-            JSON_THROW_ON_ERROR
+            ]
         );
         exit;
     }


### PR DESCRIPTION
Production environnement seems to be running with PHP 7.2.
See #17.