### PR TITLE
Enhance syntax higlighting

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -531,8 +531,11 @@ span.CodeMirror-selectedtext {
   width: 100%;
   height: 100%; }
 
-.cm-s-elegant span.cm-number, .cm-s-elegant span.cm-string, .cm-s-elegant span.cm-atom {
+.cm-s-elegant span.cm-number, .cm-s-elegant span.cm-atom {
   color: #000; }
+
+.cm-s-elegant span.cm-string {
+  color: #c42020; }
 
 .cm-s-elegant span.cm-comment {
   color: #888; }
@@ -550,7 +553,7 @@ span.CodeMirror-selectedtext {
   color: #000; }
 
 .cm-s-elegant span.cm-keyword {
-  color: #000; }
+  color: #c42020; }
 
 .cm-s-elegant span.cm-builtin {
   color: #000; }

--- a/assets/sass/codemirror_custom.scss
+++ b/assets/sass/codemirror_custom.scss
@@ -1,10 +1,11 @@
-.cm-s-elegant span.cm-number, .cm-s-elegant span.cm-string, .cm-s-elegant span.cm-atom { color: #000; }
+.cm-s-elegant span.cm-number, .cm-s-elegant span.cm-atom { color: #000; }
+.cm-s-elegant span.cm-string { color: rgb(196, 32, 32); }
 .cm-s-elegant span.cm-comment { color: #888; }
 .cm-s-elegant span.cm-meta { color: #000; }
 .cm-s-elegant span.cm-variable { color: #000; }
 .cm-s-elegant span.cm-variable-2 { color: #000; }
 .cm-s-elegant span.cm-qualifier { color: #000; }
-.cm-s-elegant span.cm-keyword { color: #000; }
+.cm-s-elegant span.cm-keyword { color: rgb(196, 32, 32); }
 .cm-s-elegant span.cm-builtin { color: #000; }
 .cm-s-elegant span.cm-link { color: #000; }
 .cm-s-elegant span.cm-error { background-color: #000; }


### PR DESCRIPTION
This makes it easier to spot parse errors (like unclosed string literal).

Colors were chosen to match overall red-black-white style of the site.

## Screenshots

### Main page
![image](https://user-images.githubusercontent.com/57403/80291035-b57a9880-8752-11ea-8329-dfb1d3466d46.png)

### Expanded editor

![image](https://user-images.githubusercontent.com/57403/80291078-08545000-8753-11ea-8697-dfa38108cae3.png)

### Parse error (unclosed string literal)

![image](https://user-images.githubusercontent.com/57403/80291050-da6f0b80-8752-11ea-8dc1-a48fc40085dc.png)

### Parse error (expanded)

![image](https://user-images.githubusercontent.com/57403/80291089-2621b500-8753-11ea-8342-c82cc24f3857.png)

