### PR TITLE
Adapt 'Code too long' message to what frontend expects

### DIFF
--- a/views/check.php
+++ b/views/check.php
@@ -45,12 +45,12 @@ if (!$fix_file) {
 
 if (strlen($file_contents) > 100000) {
     header(sprintf('HTTP/1.0 %s', 418));
-    echo json_encode(['error' => 'Code too long']);
+    echo json_encode(['error' => ['message' => 'Code too long', 'line_from' => 0]]);
     exit;
 }
 
 $php_version = $_POST['php'] ?? '8.0';
-		
+
 if (!preg_match('/^[578]\.\d$/', $php_version)) {
     echo json_encode(['error' => 'PHP version ' . $php_version . ' not supported']);
     exit;


### PR DESCRIPTION
Fixes psalm/psalm.dev#28

Output before the change:
```
Psalm runner output: 

Internal Psalm error on line undefined - undefined
```
Output after the change
```
Psalm runner output: 

Internal Psalm error on line 0 - Code too long
```