### PR TITLE
Add use_phpdoc_without_magic_call setting

### DIFF
--- a/codes.sql
+++ b/codes.sql
@@ -14,6 +14,7 @@ CREATE TABLE `psalm_web`.`codes` (
  `check_throws` bit(1) NOT NULL DEFAULT b'0',
  `strict_internal_functions` bit(1) NOT NULL DEFAULT b'0',
  `allow_phpstorm_generics` bit(1) NOT NULL DEFAULT b'0',
+ `use_phpdoc_without_magic_call` bit(1) NOT NULL DEFAULT b'0',
  PRIMARY KEY (`hash`),
  KEY `ip` (`ip`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/includes/script.php
+++ b/includes/script.php
@@ -23,6 +23,7 @@ var settingsText = {
     'check_throws': 'Check for <code>@throws</code> docblock',
     'restrict_return_types': 'Force return types to be as tight as possible',
     'allow_phpstorm_generics': 'Allow PHPStorm generic annotations (e.g. Traversable|string[])',
+    'use_phpdoc_without_magic_call': 'Use PHPDoc methods and properties without magic call.',
 };
     
 var toggleSetting = function(key) {

--- a/src/OnlineChecker.php
+++ b/src/OnlineChecker.php
@@ -202,6 +202,8 @@ class OnlineChecker
         $config->remember_property_assignments_after_call = $settings['memoize_properties'] ?? true;;
         $config->memoize_method_calls = $settings['memoize_method_calls'] ?? false;
         $config->allow_phpstorm_generics = $settings['allow_phpstorm_generics'] ?? false;
+        $config->use_phpdoc_method_without_magic_or_parent = $settings['use_phpdoc_without_magic_call'] ?? false;
+        $config->use_phpdoc_property_without_magic_or_parent = $settings['use_phpdoc_without_magic_call'] ?? false;
         $config->ignore_internal_nullable_issues = !($settings['strict_internal_functions'] ?? false);
         $config->ignore_internal_falsable_issues = !($settings['strict_internal_functions'] ?? false);
         $config->base_dir = __DIR__ . '/';

--- a/views/add_code.php
+++ b/views/add_code.php
@@ -69,7 +69,8 @@ $settings_fields = [
     'memoize_method_calls',
     'check_throws',
     'strict_internal_functions',
-    'allow_phpstorm_generics'
+    'allow_phpstorm_generics',
+    'use_phpdoc_without_magic_call',
 ];
 
 foreach ($settings_fields as $field) {

--- a/views/article.php
+++ b/views/article.php
@@ -76,6 +76,7 @@ const settings = {
     'check_throws': false,
     'strict_internal_functions': false,
     'allow_phpstorm_generics': false,
+    'use_phpdoc_without_magic_call': false,
 };
 
 var fetchAnnotations = function (code, callback, options, cm) {

--- a/views/index.php
+++ b/views/index.php
@@ -55,6 +55,7 @@ var settings = {
     'check_throws': false,
     'strict_internal_functions': false,
     'allow_phpstorm_generics': false,
+    'use_phpdoc_without_magic_call': false,
 };
 </script>
 <?php require('../includes/footer.php'); ?>

--- a/views/snippet.php
+++ b/views/snippet.php
@@ -44,7 +44,8 @@ $settings_fields = [
     'memoize_method_calls',
     'check_throws',
     'strict_internal_functions',
-    'allow_phpstorm_generics'
+    'allow_phpstorm_generics',
+    'use_phpdoc_without_magic_call',
 ];
 
 const PHP_PARSER_VERSION = '4.0.0';


### PR DESCRIPTION
The new setting `use_phpdoc_without_magic_call` would enable both [`usePhpDocMethodsWithoutMagicCall`](https://psalm.dev/docs/running_psalm/configuration/#usephpdocmethodswithoutmagiccall) and [`usePhpDocPropertiesWithoutMagicCall`](https://psalm.dev/docs/running_psalm/configuration/#usephpdocpropertieswithoutmagiccall).

Background:

* https://github.com/vimeo/psalm/issues/6023#issuecomment-871598625
* https://github.com/vimeo/psalm/issues/6024#issuecomment-871659083