### PR TITLE
Set HTTP response codes systematically

### DIFF
--- a/views/add_code.php
+++ b/views/add_code.php
@@ -1,7 +1,10 @@
 <?php
+
 ini_set("display_errors", 1); 
 ini_set("display_startup_errors", 1);
 error_reporting(-1);
+http_response_code(500);
+
 if (!isset($_POST['code']) || !isset($_POST['settings']) ) {
     http_response_code(412);
     echo 'Expecting code';
@@ -56,6 +59,7 @@ $stmt->execute([':hash' => $hash]);
 $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
 if ($result) {
+    http_response_code(200);
     echo $_SERVER['SERVER_NAME'] . '/r/' . $hash;
     exit();
 }
@@ -83,6 +87,7 @@ $port = $_SERVER['SERVER_PORT'];
 
 $server = $_SERVER['SERVER_NAME'] . ($port === 80 || $port === 443 ? '' : ':' . $port);
 
+http_response_code(200);
 echo $server . '/r/' . $hash;
 exit();
 

--- a/views/article.php
+++ b/views/article.php
@@ -1,9 +1,11 @@
 <?php
 
-require_once('../vendor/autoload.php');
 error_reporting(E_ALL);
 ini_set('html_errors', '1');
 ini_set('display_errors', '1');
+http_response_code(500);
+
+require_once('../vendor/autoload.php');
 
 $title = 'Psalm - article not found';
 $name = $_GET['name'];
@@ -17,8 +19,9 @@ $blog = new Muglug\Blog\MarkdownBlog(
 
 try {
     $article = $blog->articles->get($name);
+    http_response_code(200);
 } catch (\Exception $e) {
-    header("HTTP/1.0 404 Not Found");
+    http_response_code(404);
     echo $e->getMessage();
     exit;
 }

--- a/views/check.php
+++ b/views/check.php
@@ -1,14 +1,19 @@
 <?php
+
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
+http_response_code(500);
+
 require_once('../vendor/autoload.php');
 // not included in autoload
 
 if (!isset($_POST['code'])) {
+    http_response_code(400);
     exit;
 }
 
 if (!isset($_POST['settings'])) {
+    http_response_code(400);
     exit;
 }
 
@@ -16,6 +21,7 @@ $fix_file = $_POST['fix'] ?? false;
 
 $settings = json_decode($_POST['settings'], true);
 if (!is_array($settings)) {
+    http_response_code(400);
     exit;
 }
 
@@ -37,6 +43,7 @@ if (!$fix_file) {
         $decoded = json_decode($cached_result, true);
 
         if ($decoded['hash'] === $file_hash) {
+            http_response_code(200);
             echo $cached_result;
             exit;
         }
@@ -44,7 +51,7 @@ if (!$fix_file) {
 }
 
 if (strlen($file_contents) > 100000) {
-    header(sprintf('HTTP/1.0 %s', 418));
+    http_response_code(418);
     echo json_encode(['error' => ['message' => 'Code too long', 'line_from' => 0]]);
     exit;
 }
@@ -52,8 +59,10 @@ if (strlen($file_contents) > 100000) {
 $php_version = $_POST['php'] ?? '8.1';
 
 if (!preg_match('/^[578]\.\d$/', $php_version)) {
+    http_response_code(422);
     echo json_encode(['error' => 'PHP version ' . $php_version . ' not supported']);
     exit;
 }
 
+http_response_code(200);
 echo json_encode(PsalmDotOrg\OnlineChecker::getResults($file_contents, $settings, $fix_file, $php_version));

--- a/views/contribute.php
+++ b/views/contribute.php
@@ -1,13 +1,17 @@
 <?php
 
-require_once('../vendor/autoload.php');
 error_reporting(E_ALL);
 ini_set('html_errors', '1');
 ini_set('display_errors', '1');
+http_response_code(500);
+
+require_once('../vendor/autoload.php');
 
 $contribution_markdown = file_get_contents(dirname(__DIR__) . '/assets/pages/contribute.md');
 
 $html = Muglug\Blog\ArticleRepository::convertMarkdownToHtml($contribution_markdown, null);
+
+http_response_code(200);
 ?>
 <html>
 <head>

--- a/views/issue_redirect.php
+++ b/views/issue_redirect.php
@@ -1,5 +1,7 @@
 <?php
 
+http_response_code(500);
+
 require_once('../vendor/autoload.php');
 
 $path = (int) substr($_SERVER['REQUEST_URI'], 1);
@@ -23,12 +25,12 @@ if ($path) {
     }
 
     if (isset($map[$path])) {
-        header("HTTP/1.1 301 Moved Permanently");
+        http_response_code(301);
         header("Location: /docs/running_psalm/issues/" . $map[$path]);
         exit();
     }
 }
 
-header("HTTP/1.1 301 Moved Permanently");
+http_response_code(301);
 header("Location: /docs/running_psalm/issues/");
 exit();

--- a/views/snippet.php
+++ b/views/snippet.php
@@ -1,5 +1,9 @@
 <?php
+
+http_response_code(500);
+
 if (!isset($_GET['r']) ) {
+    http_response_code(303);
     header('Location: /');
     exit;
 }
@@ -7,6 +11,7 @@ if (!isset($_GET['r']) ) {
 $hash = trim($_GET['r']);
 
 if (!preg_match('/^[a-z0-9]+$/', $hash)) {
+    http_response_code(303);
     header('Location: /');
     exit;
 }
@@ -29,6 +34,7 @@ $stmt->execute([':hash' => $hash]);
 $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
 if (!$result) {
+    http_response_code(303);
     header('Location: /');
     exit;
 }
@@ -51,6 +57,7 @@ const PHP_PARSER_VERSION = '4.0.0';
 
 if (isset($_GET['format'])) {
     if ($_GET['format'] === 'raw') {
+        http_response_code(200);
         header('Content-Type: text/plain');
         echo $code;
         exit;
@@ -67,10 +74,12 @@ if (isset($_GET['format'])) {
         $php_version = $_GET['php'] ?? '8.0';
 
         if (!preg_match('/^[578]\.\d$/', $php_version)) {
+            http_response_code(422);
             echo json_encode(['error' => ['message' => 'PHP version ' . $php_version . ' not supported']]);
             exit;
         }
 
+        http_response_code(200);
         header('Content-Type: application/json');
         set_exception_handler([\PsalmDotOrg\ExceptionHandler::class, 'json']);
 
@@ -78,13 +87,13 @@ if (isset($_GET['format'])) {
         exit;
     }
 
-    header('HTTP/1.1 400 Bad Request');
+    http_response_code(400);
     header('Content-Type: text/plain');
     echo 'Unrecognized format';
     exit;
 }
 
-
+http_response_code(200);
 ?>
 <html>
 <head>


### PR DESCRIPTION
While running `psalm.dev` locally, I noticed that most actions always return `HTTP 200 OK`, even if there were errors. This makes it hard to spot failed requests in the browser's developer tools.

Therefore I suggest to systematically set HTTP response codes.

By setting `http_response_code(500)` at the top, we can make sure that any error actually causes a `HTTP 500 Internal Server Error`, as long as we make sure to set it to a different status code before we emit any output.