### PR TITLE
escapes chars in taint snippets

### DIFF
--- a/includes/script.php
+++ b/includes/script.php
@@ -156,6 +156,10 @@ var fetchAnnotations = function (code, callback, options, cm) {
                                     function (reference) {
                                         let snippet = reference.snippet;
 
+                                        snippet = snippet.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
+                                            return '&#'+i.charCodeAt(0)+';';
+                                        });
+
                                         let selection_start = reference.from - reference.snippet_from;
                                         let selection_end = reference.to - reference.snippet_from;
 
@@ -180,6 +184,10 @@ var fetchAnnotations = function (code, callback, options, cm) {
                                         }
 
                                         let snippet = reference.snippet;
+
+                                        snippet = snippet.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
+                                            return '&#'+i.charCodeAt(0)+';';
+                                        });
 
                                         let selection_start = reference.from - reference.snippet_from;
                                         let selection_end = reference.to - reference.snippet_from;


### PR DESCRIPTION
This should prevent an XSS breach reported here: https://github.com/vimeo/psalm/issues/7609

TBH, I didn't test it, so a good look at review would be great