### PR TITLE
typecast port to int

### DIFF
--- a/views/add_code.php
+++ b/views/add_code.php
@@ -58,7 +58,7 @@ $stmt = $pdo->prepare('select `code`, `created_on` from `codes` where `hash` = :
 $stmt->execute([':hash' => $hash]);
 $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-$port = $_SERVER['SERVER_PORT'];
+$port = (int) $_SERVER['SERVER_PORT'];
 $server = $_SERVER['SERVER_NAME'] . ($port === 80 || $port === 443 ? '' : ':' . $port);
 
 if ($result) {


### PR DESCRIPTION
Condition checks for 80/443 as int, but port is always a string. Therefore the port is always set.

Realized this only after my last PR, since browser strip this internally, but the copied URL had the port in it.