### PR TITLE
Override --md-typeset-color

### DIFF
--- a/assets/sass/mkdocs_material_extra.scss
+++ b/assets/sass/mkdocs_material_extra.scss
@@ -7,6 +7,10 @@ body {
 	-moz-osx-font-smoothing: inherit;
 }
 
+:root > * {
+	--md-typeset-color: initial;
+}
+
 .md-header {
 	color: #000;
 


### PR DESCRIPTION
Setting var `--md-typeset-color` to `initial` should make https://github.com/squidfunk/mkdocs-material/blob/6119df5d56fcdc90e25c5b1a47f7d2eba77f589e/src/assets/stylesheets/main/_typeset.scss#L43 use the color that was set by the user-agent/browser.

This does not seem like an ideal fix to me but it does fix a possible lack of contrast, as mentioned by me in: https://github.com/vimeo/psalm/issues/9128 .