### PR TITLE
Exclude `ghostwriter/*` psalm-plugins

### DIFF
--- a/src/PluginRepository.php
+++ b/src/PluginRepository.php
@@ -51,8 +51,13 @@ final class PluginRepository
             );
         }
 
+        $packageNames = array_diff(
+            $plugin_names['packageNames'],
+            ['ghostwriter/example-psalm-plugin','ghostwriter/phpunit-psalm-plugin','ghostwriter/psalm-plugin'],
+        );
+
         $plugins = [];
-        foreach ($plugin_names['packageNames'] as $package_name) {
+        foreach ($packageNames as $package_name) {
             $plugin_json = file_get_contents("https://packagist.org/packages/$package_name.json");
             if (!$plugin_json) {
                 continue;


### PR DESCRIPTION
I unintentionally broke the [plugin ranking system](https://psalm.dev/plugins).

My bad.

It's unfair to other authors.

I'm removing my plugins until there is a new implementation.