### PR TITLE
Dev workflow improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM php:8.2-apache
+FROM php:8.3-apache
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY docker/php/vhost.conf /etc/apache2/sites-available/000-default.conf
 
 RUN apt-get update && apt-get install -y \
-        unzip \
-        git \
-    && rm -rf /var/lib/apt/lists/*
+  unzip \
+  git \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite && a2enmod headers
 RUN docker-php-ext-install pdo_mysql

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Has the source for psalm.dev
 
 ## To build docs (for local preview)
 
-- Run `composer update` (requires [Composer](https://getcomposer.org))
-- Run `mkdocs build` (requires Python & [MkDocs](https://www.mkdocs.org/))
+- Or `docker-compose run --rm mkdocs build`
 
 ## To build styles (these files get committed)
 
-- Run `npx webpack` (requires Node)
+- Run `docker-compose exec node npx webpack`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,5 +46,15 @@ services:
     networks:
       - backend
 
+  mkdocs:
+    container_name: mkdocs
+    image: squidfunk/mkdocs-material
+    profiles:
+      - cli # not an actual profile, just to make sure it's not started automatically
+    volumes:
+      - type: bind
+        source: "${PWD}"
+        target: /docs
+
 networks:
   backend:


### PR DESCRIPTION
Switch completely to docker based workflow, so that contributors do not
have to install tools like python on their host machines.