### PR TITLE
Pass missing required argument to connectSinksAndSources

### DIFF
--- a/src/OnlineChecker.php
+++ b/src/OnlineChecker.php
@@ -112,7 +112,7 @@ class OnlineChecker
             $file_checker->analyze($context);
 
             if ($codebase->taint_flow_graph) {
-                $codebase->taint_flow_graph->connectSinksAndSources();
+                $codebase->taint_flow_graph->connectSinksAndSources($codebase->progress);
             }
 
             if (($settings['unused_methods'] ?? false) || strpos($file_contents, '<?php // findUnusedCode') === 0) {


### PR DESCRIPTION
Needed to unbreak taint analysis, broken since https://github.com/vimeo/psalm/commit/babe8b2b7ec6de4f60e589fe3afd6120c9c8cdc8.

Fixes #110 